### PR TITLE
tk_nuke_writenode.handler: Set file format based on image_type from p…

### DIFF
--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1526,6 +1526,9 @@ class TankWriteNodeHandler(object):
         fields["MM"] = today.month
         fields["DD"] = today.day
 
+        # RDO - get the image_type key from the node profile "file_type"
+        fields['image_type'] = node['tk_file_type'].value()
+
         # validate the output name - be backwards compatible with 'channel' as well
         for key_name in ["output", "channel"]:
             if key_name in fields:


### PR DESCRIPTION
[Ticket](https://shotgun1.rodeofx.com/page/12608#Ticket_6357_Tank%20-%20Tank%20write%20-%20Preprocess%20Temp%20Jpeg)
Set the file type based on the node profile ("file_type")

**Needed for** [tk-config PR #89](https://bitbucket.org/rodeofx/tk_config_rdo_default/pull-request/89/wip-nuke-preprocess-jpeg-6537/diff)

Same PR as https://github.com/rodeofx/tk-nuke-writenode/pull/1, the only change is where this PR will be merged.
